### PR TITLE
Solved row/column error when transforming from homogeneous to euclidean coordinates

### DIFF
--- a/src/camFusion_Student.cpp
+++ b/src/camFusion_Student.cpp
@@ -29,8 +29,8 @@ void clusterLidarWithROI(std::vector<BoundingBox> &boundingBoxes, std::vector<Li
         // project Lidar point into camera
         Y = P_rect_xx * R_rect_xx * RT * X;
         cv::Point pt;
-        pt.x = Y.at<double>(0, 0) / Y.at<double>(0, 2); // pixel coordinates
-        pt.y = Y.at<double>(1, 0) / Y.at<double>(0, 2);
+        pt.x = Y.at<double>(0, 0) / Y.at<double>(2, 0); // pixel coordinates
+        pt.y = Y.at<double>(1, 0) / Y.at<double>(2, 0);
 
         vector<vector<BoundingBox>::iterator> enclosingBoxes; // pointers to all bounding boxes which enclose the current Lidar point
         for (vector<BoundingBox>::iterator it2 = boundingBoxes.begin(); it2 != boundingBoxes.end(); ++it2)

--- a/src/lidarData.cpp
+++ b/src/lidarData.cpp
@@ -121,8 +121,8 @@ void showLidarImgOverlay(cv::Mat &img, std::vector<LidarPoint> &lidarPoints, cv:
 
             Y = P_rect_xx * R_rect_xx * RT * X;
             cv::Point pt;
-            pt.x = Y.at<double>(0, 0) / Y.at<double>(0, 2);
-            pt.y = Y.at<double>(1, 0) / Y.at<double>(0, 2);
+            pt.x = Y.at<double>(0, 0) / Y.at<double>(2, 0);
+            pt.y = Y.at<double>(1, 0) / Y.at<double>(2, 0);
 
             float val = it->x;
             int red = min(255, (int)(255 * abs((val - maxVal) / maxVal)));


### PR DESCRIPTION
The _Y_ matrix has three rows and one column, so the call to

```c++
Y.at<double>(0, 2)
```

Should throw an exception. I don't know why with Linux there is not any exception, but when you run it on Windows you get the expected exception.